### PR TITLE
New metrics added for Latency(TTFB), Connection Time, Request Duration, Idle Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@ jmeter_samples_latency{sampler_name="local-metrics",code="200",success="true",qu
 jmeter_samples_latency{sampler_name="local-metrics",code="200",success="true",quantile="0.99",} 11.0
 jmeter_samples_latency_count{sampler_name="local-metrics",code="200",success="true",} 9.0
 jmeter_samples_latency_sum{sampler_name="local-metrics",code="200",success="true",} 132.0
+# HELP jmeter_samples_ttfb_seconds Summary for sample latency(TTFB) in seconds
+# TYPE jmeter_samples_ttfb_seconds summary
+jmeter_samples_ttfb_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.5",} 4.0
+jmeter_samples_ttfb_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.99",} 5.0
+jmeter_samples_ttfb_seconds_count{sampler_name="local-metrics",code="200",success="true",} 18.0
+jmeter_samples_ttfb_seconds_sum{sampler_name="local-metrics",code="200",success="true",} 73.0
+# HELP jmeter_samples_duration_seconds Summary for sample duration in seconds
+# TYPE jmeter_samples_duration_seconds summary
+jmeter_samples_duration_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.5",} 4.0
+jmeter_samples_duration_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.99",} 5.0
+jmeter_samples_duration_seconds_count{sampler_name="local-metrics",code="200",success="true",} 18.0
+jmeter_samples_duration_seconds_sum{sampler_name="local-metrics",code="200",success="true",} 74.0
+# HELP jmeter_samples_idle_time_seconds Summary for sample idle time in seconds
+# TYPE jmeter_samples_idle_time_seconds summary
+jmeter_samples_idle_time_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.5",} 0.0
+jmeter_samples_idle_time_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.99",} 0.0
+jmeter_samples_idle_time_seconds_count{sampler_name="local-metrics",code="200",success="true",} 18.0
+jmeter_samples_idle_time_seconds_sum{sampler_name="local-metrics",code="200",success="true",} 0.0
+# HELP jmeter_samples_connect_time_seconds Summary for sample connect time in seconds
+# TYPE jmeter_samples_connect_time_seconds summary
+jmeter_samples_connect_time_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.5",} 0.0
+jmeter_samples_connect_time_seconds{sampler_name="local-metrics",code="200",success="true",quantile="0.99",} 0.0
+jmeter_samples_connect_time_seconds_count{sampler_name="local-metrics",code="200",success="true",} 18.0
+jmeter_samples_connect_time_seconds_sum{sampler_name="local-metrics",code="200",success="true",} 0.0
 ```
 
 ## Examples in Grafana

--- a/src/main/java/com/github/johrstrom/listener/PrometheusListener.java
+++ b/src/main/java/com/github/johrstrom/listener/PrometheusListener.java
@@ -114,16 +114,18 @@ public class PrometheusListener extends AbstractListenerElement
 			// build the label values from the event and observe the sampler
 			// metrics
 			String[] samplerLabelValues = this.labelValues(event);
-			if (collectSamples)
+			if (collectSamples) {
 				samplerCollector.labels(samplerLabelValues).observe(event.getResult().getTime());
 				// Prometheus metrics naming, base unit is Seconds
-				samplerElaspedTimeCollector.labels(samplerLabelValues).observe(event.getResult().getTime() / 1000);
-				samplerLatencyCollector.labels(samplerLabelValues).observe(event.getResult().getLatency() / 1000);
-				samplerIdleTimeCollector.labels(samplerLabelValues).observe(event.getResult().getIdleTime() / 1000);
-				samplerConnectTimeCollector.labels(samplerLabelValues).observe(event.getResult().getConnectTime() / 1000);
+				samplerElaspedTimeCollector.labels(samplerLabelValues).observe(event.getResult().getTime() / 1000.0);
+				samplerLatencyCollector.labels(samplerLabelValues).observe(event.getResult().getLatency() / 1000.0);
+				samplerIdleTimeCollector.labels(samplerLabelValues).observe(event.getResult().getIdleTime() / 1000.0);
+				samplerConnectTimeCollector.labels(samplerLabelValues).observe(event.getResult().getConnectTime() / 1000.0);
+			}
 
-			if (collectThreads)
+			if (collectThreads) {
 				threadCollector.set(JMeterContextService.getContext().getThreadGroup().getNumberOfThreads());
+			}
 
 			// if there are any assertions to
 			if (collectAssertions) {
@@ -463,7 +465,7 @@ public class PrometheusListener extends AbstractListenerElement
 			
 			if (SampleEvent.getVarCount() > 0) {
 				labelNames = this.combineConfigLabelsWithSampleVars();
-			}else {
+			} else {
 				labelNames = this.samplerConfig.getLabels();
 			}
 			


### PR DESCRIPTION
**Review action required:** Current Metric name is confusing
'_jmeter_samples_latency_' metrics is returning 'elapsed time' instead of actual 'latency' value
_In jmeter terms 'latency' is time to first byte(TTFB),_

**New Metrics Included:(old metrics remains intact)**
_jmeter_samples_ttfb_seconds_ : latency(ttfb)
_jmeter_samples_duration_seconds_ : elasped  time
_jmeter_samples_idle_time_seconds_ : idle time
_jmeter_samples_connect_time_seconds_ : connection time